### PR TITLE
Fixing coordinates issue

### DIFF
--- a/src/SpacePlanning/Generate/Packers/CuboidPacker.cs
+++ b/src/SpacePlanning/Generate/Packers/CuboidPacker.cs
@@ -21,7 +21,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
 
         public List<int> PackedIndices { get; private set; }
 
-        public List<Cuboid> RemainingItems { get; private set; }
+        public List<int> RemainingIndices { get; private set; }
 
         public double PercentContainerVolumePacked { get; private set; }
 
@@ -35,7 +35,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
         {
             this.PackedItems = new List<Cuboid>();
             this.PackedIndices = new List<int>();
-            this.RemainingItems = new List<Cuboid>();
+            this.RemainingIndices = new List<int>();
             this.bin = null;
         }
 
@@ -67,7 +67,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
 
             // record results in this packer instance
             this.PackedItems = CuboidsFromItems(packingResult.PackedItems);
-            this.RemainingItems = CuboidsFromItems(packingResult.UnpackedItems);
+            this.RemainingIndices = IdsFromItems(packingResult.UnpackedItems);
             this.PackedIndices = IdsFromItems(packingResult.PackedItems);
             this.PercentContainerVolumePacked = decimal.ToDouble(packingResult.PercentContainerVolumePacked);
             this.PercentItemVolumePacked = decimal.ToDouble(packingResult.PercentItemVolumePacked);
@@ -174,7 +174,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
         private static Cuboid CuboidFromItem(Item item)
         {
             var lowPoint = Point.ByCoordinates(Convert.ToDouble(item.CoordX), Convert.ToDouble(item.CoordZ), Convert.ToDouble(item.CoordY));
-            Point highPoint = lowPoint.Add(Vector.ByCoordinates(Convert.ToDouble(item.Dim1), Convert.ToDouble(item.Dim2), Convert.ToDouble(item.Dim3)));
+            Point highPoint = lowPoint.Add(Vector.ByCoordinates(Convert.ToDouble(item.PackDimX), Convert.ToDouble(item.PackDimZ), Convert.ToDouble(item.PackDimY)));
             var cuboid = Cuboid.ByCorners(lowPoint, highPoint);
 
             // Dispose redundant intermediate geometry

--- a/src/SpacePlanning/Generate/Packers/IPacker.cs
+++ b/src/SpacePlanning/Generate/Packers/IPacker.cs
@@ -6,7 +6,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
     {
         List<int> PackedIndices { get; }
         List<TItem> PackedItems { get; }
-        List<TItem> RemainingItems { get; }
+        List<int> RemainingIndices { get; }
 
         void PackOneContainer(
             List<TItem> items,

--- a/src/SpacePlanning/Generate/Packers/RectanglePacker.cs
+++ b/src/SpacePlanning/Generate/Packers/RectanglePacker.cs
@@ -24,7 +24,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
         /// <summary>
         /// The rectangles that could not be packed and are outside the bin.
         /// </summary>
-        public List<Rectangle> RemainingItems { get; }
+        public List<int> RemainingIndices { get; }
 
         /// <summary>
         /// The indices of the rectangles that have been packed from the input list of rectangles.
@@ -41,7 +41,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
         {
             this.FreeRectangles = new List<FreeRectangle>();
             this.PackedItems = new List<Rectangle>();
-            this.RemainingItems = new List<Rectangle>();
+            this.RemainingIndices = new List<int>();
             this.PackedIndices = new List<int>();
         }
 
@@ -167,7 +167,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate.Packers
 
             if (freeRect == null)
             {
-                this.RemainingItems.Add(item);
+                this.RemainingIndices.Add(itemIndex);
                 return false;
             }
 

--- a/src/SpacePlanning/Generate/Packing.cs
+++ b/src/SpacePlanning/Generate/Packing.cs
@@ -10,7 +10,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate
     {
         private const string packedItemsOutputPort = "Packed Items";
         private const string indicesOutputPort = "Packed Indices";
-        private const string remainingItemsOutputPort = "Remaining Items";
+        private const string remainingIndicesOutputPort = "Remaining Indices";
         private const string percentContainerVolumePackedPort = "% Container Volume Packed";
         private const string percentItemVolumePackedPort = "% Items Volume Packed";
 
@@ -26,7 +26,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate
         /// <returns name="Packed Items">List of packed rectangles for each of the containers provided.</returns>
         /// <returns name="Packed Indices">Indices of packed rectangles for correlation to input items list.</returns>
         /// <returns name="Remaining Items">Items (rectangles) that didn't get packed.</returns>
-        [MultiReturn(new[] { packedItemsOutputPort, indicesOutputPort, remainingItemsOutputPort })]
+        [MultiReturn(new[] { packedItemsOutputPort, indicesOutputPort, remainingIndicesOutputPort })]
         public static Dictionary<string, object> PackRectangles(
             List<Rectangle> items,
             List<Rectangle> containers,
@@ -48,7 +48,7 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate
         /// <returns name="Remaining Items">Cuboids that didn't get packed.</returns>
         /// <returns name="% Container Volume Packed">Metric : percentage of each container volume that was packed.</returns>
         /// <returns name="% Item Volume Packed">Metric : percentage expressing how much of total items volume was packed in each container.</returns>
-        [MultiReturn(new[] { packedItemsOutputPort, indicesOutputPort, remainingItemsOutputPort, percentContainerVolumePackedPort, percentItemVolumePackedPort })]
+        [MultiReturn(new[] { packedItemsOutputPort, indicesOutputPort, remainingIndicesOutputPort, percentContainerVolumePackedPort, percentItemVolumePackedPort })]
         public static Dictionary<string, object> PackCuboids(
             List<Cuboid> items,
             List<Cuboid> containers)
@@ -92,13 +92,13 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate
             // we only need the remaining rectangles from the last bin packing result
             // since the same list of remaining rectangles is used sequentially to pack all bins.
             // using all lists of remaining rects would just show us the progression of what remained after each pack
-            var remainRects = packers.LastOrDefault()?.RemainingItems;
+            var remainIndices = packers.LastOrDefault()?.RemainingIndices;
 
             return new Dictionary<string, object>
             {
                 {packedItemsOutputPort, packedRects},
                 {indicesOutputPort, packedIndices},
-                {remainingItemsOutputPort, remainRects}
+                {remainingIndicesOutputPort, remainIndices}
             };
         }
 
@@ -115,13 +115,13 @@ namespace Autodesk.RefineryToolkits.SpacePlanning.Generate
             var percentItemVolumePacked = packers.Select(x => x.PercentItemVolumePacked).ToList();
 
             // we only need the remaining rectangles from the last bin packing result
-            var remainCuboids = packers.LastOrDefault()?.RemainingItems;
+            var remainIndices = packers.LastOrDefault()?.RemainingIndices;
 
             return new Dictionary<string, object>
             {
                 { packedItemsOutputPort, packedCuboids},
                 { indicesOutputPort, packedIndices},
-                { remainingItemsOutputPort, remainCuboids},
+                { remainingIndicesOutputPort, remainIndices},
                 { percentContainerVolumePackedPort, percentContainerVolumePacked},
                 { percentItemVolumePackedPort, percentItemVolumePacked}
             };


### PR DESCRIPTION
closes #129 

Fixed issue where we were using the wrong coordinates when converting packing items into dynamo Cuboids also changed the remaining items output to return the indices of the remaining items instead of the actual Cuboids.  