### PR TITLE
add nuspec to publish nuget to artifactory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,5 +8,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <PlatformTarget>x64</PlatformTarget>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
 </Project>

--- a/RefineryToolkit.nuspec
+++ b/RefineryToolkit.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>RefineryToolkit</id>
+        <version>1.1.1</version>
+        <authors>Autodesk</authors>
+        <owners>Autodesk</owners>
+        <license type="expression">Apache-2.0</license>
+        <projectUrl>https://github.com/DynamoDS/RefineryToolkits</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Collection of nodes to be used in Generative Design workflows.</description>
+        <copyright>Copyright Autodesk 2024</copyright>
+    </metadata>
+    <files>
+        <file src="build\pkg.json" target="" />
+        <file src="build\bin\**" target="bin\" exclude="bin\*.pdb;" />
+        <file src="build\Extra\**" target="Extra\" />
+    </files>
+</package>


### PR DESCRIPTION
Added the nuget package to artifactory for consumption in DaaS, for which I first created this nuspec.

TODO:
- Add cicd step to the pipeline to auto-publish the package to artifactory as a deployment step.

Reviewer: @twastvedt 